### PR TITLE
Add a `tomcatRestart` Gradle task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,7 @@ script:
   # test embedded tomcat
   - ./gradlew -i -S tomcatInstall
   - ./gradlew -i -S tomcatStart
+  - ./gradlew -i -S tomcatRestart
   - ./gradlew -i -S tomcatStop
   - ./gradlew -i -S tomcatClearLogs
   - |

--- a/gradle/tasks/tomcat.gradle
+++ b/gradle/tasks/tomcat.gradle
@@ -163,6 +163,13 @@ task tomcatStop() {
     }
 }
 
+task tomcatRestart(dependsOn: ['tomcatStop', 'tomcatStart']) {
+    group 'Tomcat'
+    description 'Restart the embedded Tomcat servlet container'
+
+    tomcatStart.mustRunAfter(tomcatStop)
+}
+
 task tomcatClearLogs(type: Delete) {
     group 'Tomcat'
     description 'Delete all log files within Tomcat'


### PR DESCRIPTION
##### Checklist

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] tests are included

##### Description of change

This pull request simply adds a `tomcatRestart` Gradle task that first runs `tomcatStop` then `tomcatStart`. This can be very handy when debugging a uPortal setup and shouldn't be a maintenance burden.

Have a nice day.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
