### PR TITLE
fix: set type to avoid nosniff browser blocking

### DIFF
--- a/data/quickstart/portlet-definition/notification-icon.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/notification-icon.portlet-definition.xml
@@ -80,8 +80,8 @@
         <readOnly>false</readOnly>
         <value>
             <![CDATA[
-                <script src="/resource-server/webjars/vue/dist/vue.min.js"></script>
-                <script src="/resource-server/webjars/uportal__notification-icon/dist/notification-icon.min.js" defer></script>
+                <script src="/resource-server/webjars/vue/dist/vue.min.js" type="text/javascript"></script>
+                <script src="/resource-server/webjars/uportal__notification-icon/dist/notification-icon.min.js" type="text/javascript" defer></script>
                 <notification-icon
                     see-all-notifications-url="/uPortal/p/notification-list"
                     navigation-strategy="list"


### PR DESCRIPTION
Setting the MIME type si required to avoid X-Content-Type-Options: nosniff browser blocking

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [X] the [individual contributor license agreement][] is signed
-   [X] commit message follows [commit guidelines][]
-   [ ] tests are included
-   [ ] documentation is changed or added
-   [ ] [message properties][] have been updated with new phrases
-   [ ] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
