### PR TITLE
Doc: fix command from gradle change

### DIFF
--- a/docs/en/tomcat/debugging-with-jpda.md
+++ b/docs/en/tomcat/debugging-with-jpda.md
@@ -4,5 +4,5 @@ Tomcat has support for step through debugging through the Java Platform Debugger
 To enable JPDA add a flag when starting tomcat.
 
 ```sh
-./gradlew tomcatStart --with-jpda
+./gradlew tomcatStart -Pwith-jpda
 ```


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [X] the [individual contributor license agreement][] is signed
-   [X] commit message follows [commit guidelines][]
-   [ ] tests are included
-   [ ] documentation is changed or added
-   [ ] [message properties][] have been updated with new phrases
-   [ ] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
the parametter passed as `-- with-jpda` return an error 
```
Problem configuring task :tomcatStart from command line.
> Unknown command-line option '--with-jpda'.
```
And so to fix the problem and to read the param as a project's property we need to pass it with -P argument

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
