### PR TITLE
fix: updated Dockerfile to add wget to image to support the healthcheck

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,9 @@
 # This image aims for maximum slimness
 FROM adoptopenjdk:8-jdk-hotspot
 
+RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y wget && \
+    apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
 # For this image, we only need the fully-assembled Tomcat container
 COPY .gradle/tomcat tomcat
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
This addresses an issue where the resulting image is failing the healthcheck since it does not have `wget`.
```
$ sudo docker container ls --filter name="my-dev_uPortal_1"
CONTAINER ID   IMAGE                   COMMAND                  CREATED         STATUS                     PORTS      NAMES
aef9786ceac9   apereo/uportal:latest   "/tomcat/bin/catalin…"   4 minutes ago   Up 4 minutes (unhealthy)   8080/tcp   my-dev_uPortal_1
```


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
