### PR TITLE
chore: set startup parameters to secure Log4j2

### DIFF
--- a/etc/tomcat/bin/setenv.bat
+++ b/etc/tomcat/bin/setenv.bat
@@ -7,6 +7,10 @@ rem http://confluence.atlassian.com/display/DOC/Garbage+Collector+Performance+Is
 rem Prevent "Unrecognized Name" SSL warning
 set CATALINA_OPTS=%CATALINA_OPTS% -Djsse.enableSNIExtension=false
 
+rem CVE-2021-44228 Log4j2
+set CATALINA_OPTS=%CATALINA_OPTS% -Dcom.sun.jndi.ldap.object.trustURLCodebase=false
+set CATALINA_OPTS=%CATALINA_OPTS% -Dlog4j2.formatMsgNoLookups=true
+
 rem Checking if anyother garbage collectors have been defined. If no other garbage
 rem collector is present, default to G1GC
 rem List of options taken from:

--- a/etc/tomcat/bin/setenv.sh
+++ b/etc/tomcat/bin/setenv.sh
@@ -4,6 +4,10 @@ CATALINA_OPTS="$CATALINA_OPTS -XX:+PrintCommandLineFlags"
 # Prevent "Unrecognized Name" SSL warning
 CATALINA_OPTS="$CATALINA_OPTS -Djsse.enableSNIExtension=false"
 
+# CVE-2021-44228 Log4j2
+CATALINA_OPTS="$CATALINA_OPTS -Dcom.sun.jndi.ldap.object.trustURLCodebase=false"
+CATALINA_OPTS="$CATALINA_OPTS -Dlog4j2.formatMsgNoLookups=true"
+
 # We need to send a 'portal.home' system property to the JVM;  use the value of PORTAL_HOME, if
 # present, or fall back to a value calculated from $CATALINA_BASE
 [ -z "$PORTAL_HOME" ] && PORTAL_HOME="$CATALINA_BASE/portal"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
While uPortal and portlets are not susceptible to CVE-2021-44228, including the startup parameters to help guard custom code that may include Log4j2.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
