### PR TITLE
fix: renamed pbookmarks portlet definition to bookmarks

### DIFF
--- a/data/quickstart/fragment-layout/welcome-lo.fragment-layout.xml
+++ b/data/quickstart/fragment-layout/welcome-lo.fragment-layout.xml
@@ -19,11 +19,11 @@
     under the License.
 
 -->
-<layout xmlns:dlm="http://www.uportal.org/layout/dlm" script="classpath://org/jasig/portal/io/import-layout_v3-2.crn" 
+<layout xmlns:dlm="http://www.uportal.org/layout/dlm" script="classpath://org/jasig/portal/io/import-layout_v3-2.crn"
   username="welcome-lo" >
   <folder ID="s1" hidden="false" immutable="false" name="Root folder" type="root" unremovable="true">
     <!--
-     | Hidden folders do not propagate to regular users, and fragment owner 
+     | Hidden folders do not propagate to regular users, and fragment owner
      | accounts don't receive (other) fragments at all;  Fragment owners must
      | have their own copies of the minimal portlets required to view and manage
      | their own layouts.
@@ -47,7 +47,7 @@
         </structure-attribute>
         <channel fname="email-preview-demo" unremovable="false" hidden="false" immutable="false" ID="n9" dlm:moveAllowed="false" dlm:deleteAllowed="false"/>
         <channel fname="weather" unremovable="false" hidden="false" immutable="false" ID="n10"/>
-        <channel fname="pbookmarks" unremovable="false" hidden="false" immutable="false" ID="n11" dlm:moveAllowed="false" dlm:deleteAllowed="false"/>
+        <channel fname="bookmarks" unremovable="false" hidden="false" immutable="false" ID="n11" dlm:moveAllowed="false" dlm:deleteAllowed="false"/>
       </folder>
       <folder ID="s12" hidden="false" immutable="false" name="Column" type="regular" unremovable="false">
         <structure-attribute>

--- a/data/quickstart/portlet-definition/bookmarks.portlet-definition.xml
+++ b/data/quickstart/portlet-definition/bookmarks.portlet-definition.xml
@@ -22,7 +22,7 @@
 <portlet-definition xmlns="https://source.jasig.org/schemas/uportal/io/portlet-definition" xmlns:ns2="https://source.jasig.org/schemas/uportal" xmlns:ns3="https://source.jasig.org/schemas/uportal/io/permission-owner" xmlns:ns4="https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor" xmlns:ns5="https://source.jasig.org/schemas/uportal/io/portlet-type" xmlns:ns6="https://source.jasig.org/schemas/uportal/io/user" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.0" xsi:schemaLocation="https://source.jasig.org/schemas/uportal/io/portlet-definition https://source.jasig.org/schemas/uportal/io/portlet-definition/portlet-definition-4.0.xsd">
     <title>Bookmarks</title>
     <name>Bookmarks</name>
-    <fname>pbookmarks</fname>
+    <fname>bookmarks</fname>
     <desc>Bookmarks portlet</desc>
     <type>Bookmarks Portlet</type>
     <timeout>60000</timeout>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
