### PR TITLE
feat: separate out tomcatConfig task from tomcatInstall

### DIFF
--- a/gradle/tasks/tomcat.gradle
+++ b/gradle/tasks/tomcat.gradle
@@ -37,6 +37,7 @@ task tomcatInstall() {
     group 'Tomcat'
     description 'Downloads the Apache Tomcat servlet container and performs the necessary configuration steps'
     dependsOn ':portalProperties'
+    finalizedBy 'tomcatConfig'
 
     doLast {
         String serverHome = rootProject.ext['buildProperties'].getProperty('server.home')
@@ -69,6 +70,16 @@ task tomcatInstall() {
             from "${tomcatTmpDir}/apache-tomcat-${tomcatVersion}"
             into serverHome
         }
+    }
+}
+
+task tomcatConfig() {
+    group 'Tomcat'
+    description 'Configures Tomcat servlet container, used to update an existing Tomcat install'
+    dependsOn ':portalProperties'
+
+    doLast {
+        String serverHome = rootProject.ext['buildProperties'].getProperty('server.home')
 
         //  Configure our settings by overlaying etc/tomcat
         copy {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
Extracting the code that configures Tomcat so that implementers can target existing Tomcat installs. This happens enough in current higher ed environments where Ops prefers to use their own Tomcat installations.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
