### PR TITLE
UPSE-293: update for ResourceServingWebapp to run w/ Java 11

### DIFF
--- a/overlays/ResourceServingWebapp/build.gradle
+++ b/overlays/ResourceServingWebapp/build.gradle
@@ -1,5 +1,7 @@
 dependencies {
     runtime "org.jasig.resourceserver:resource-server-webapp:${resourceServerVersion}@war"
+    runtime "javax.xml.bind:jaxb-api:2.3.1"
+    runtime "com.sun.xml.bind:jaxb-impl:2.3.3"
 }
 
 war {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [X] the [individual contributor license agreement][] is signed
-   [X] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
ResourceServingWebapp needed to include two JAXB libraries in order to run with a Java 11 JDK.
Because we use a very old/outdated version of ResourceServingWebapp, it was easier to add the dependencies to the overlay rather than trying to update the actual project.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
