### PR TITLE
UPSE-362: updates for CAS Webapp to run w/ Java 11

### DIFF
--- a/overlays/cas/build.gradle
+++ b/overlays/cas/build.gradle
@@ -6,6 +6,8 @@ dependencies {
         exclude group: 'xerces', module: 'xercesImpl'
     }
     runtime "net.sf.ehcache:ehcache-core:${casEhcacheVersion}"
+    runtime "org.aspectj:aspectjrt:1.9.7"
+    runtime "org.aspectj:aspectjweaver:1.9.7"
     runtime "org.jasig.cas:cas-server-webapp:${casServerVersion}@war"
     runtime("org.jasig.cas:cas-server-extension-clearpass:${casServerVersion}") {
         exclude group: 'commons-logging', module: 'commons-logging'
@@ -42,4 +44,6 @@ war {
     exclude 'WEB-INF/lib/cas-client-core-3.2.1.jar'
     exclude 'WEB-INF/lib/commons-collections*jar'
     exclude 'WEB-INF/lib/xml-apis-1.0.b2.jar'
+    exclude 'WEB-INF/lib/aspectjrt-1.6.10.jar'
+    exclude 'WEB-INF/lib/aspectjweaver-1.6.10.jar'
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [X] the [individual contributor license agreement][] is signed
-   [X] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
The CAS webapp was failing to startup when running Tomcat with Java 11.
Issue is that it needs newer versions of AspectJ jars.
Updated overlay build.gradle to replace older jars with newer ones that work with Java 11.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
