### PR TITLE
feat: add task skinDeployFiles

### DIFF
--- a/gradle/tasks/properties.gradle
+++ b/gradle/tasks/properties.gradle
@@ -7,7 +7,7 @@ import java.nio.file.Paths
 task javaVersionCheck() {
     group 'Verification'
     description 'Ensures the current Java version is supported'
-    
+
     doLast {
         def supportedJavaVersions = [ JavaVersion.VERSION_1_8, JavaVersion.VERSION_11 ];
         def currentJavaVersion = JavaVersion.current();
@@ -34,8 +34,8 @@ task javaVersionCheck() {
 task portalProperties() {
     group 'Portal'
     description 'Loads properties for the CLI tools for Packaging, Deploying, and Database Import/Export'
-    
-    doLast() {
+
+    configure {
 
         /*
          * The Properties object we need to load already exists.

--- a/overlays/uPortal/build.gradle
+++ b/overlays/uPortal/build.gradle
@@ -147,6 +147,22 @@ else {
         }
     }
 
+    task skinDeployFiles(type: Copy) {
+        dependsOn project.rootProject.tasks.portalProperties
+
+        File serverBase = project.rootProject.file(project.rootProject.ext['buildProperties'].getProperty('server.home'))
+        logger.lifecycle("serverBase: ${serverBase}")
+        File deployDir = new File(serverBase, "webapps/${project.name}/media/skins/respondr")
+        logger.lifecycle("deployDir: ${deployDir}")
+
+        doFirst {
+            logger.lifecycle("Copying skin files from ${skinTmpDir} to ${deployDir}")
+        }
+
+        from skinTmpDir
+        into deployDir
+    }
+
     war.dependsOn {
         tasks.findAll { task -> task.name.startsWith('compileLess') }
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [ ] the [individual contributor license agreement][] is signed
-   [ ] commit message follows [commit guidelines][]
-   [ ] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->
Add a new task, skinDeployFiles, so that skin development does not require Tomcat restarts and `tomcatDeploy`.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
