### PR TITLE
fix: copy in War Overlay Plugin

### DIFF
--- a/buildSrc/src/main/groovy/scaldingspoon/gradle/WarOverlayPlugin.groovy
+++ b/buildSrc/src/main/groovy/scaldingspoon/gradle/WarOverlayPlugin.groovy
@@ -1,0 +1,56 @@
+package scaldingspoon.gradle
+
+import org.gradle.api.Action
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.file.DuplicatesStrategy
+import org.gradle.api.plugins.WarPlugin
+import org.gradle.api.tasks.bundling.War
+
+/**
+ * Plugin class to support WAR overlay
+ */
+class WarOverlayPlugin implements Plugin<Project> {
+    @Override
+    void apply(Project project) {
+        project.plugins.apply(WarPlugin)
+        project.convention.plugins.warOverlay = new WarOverlayPluginConvention()
+
+        project.tasks.withType(War, new Action<War>() {
+            @Override
+            void execute(War war) {
+                war.duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+                war.doFirst {
+                    war.classpath = war.classpath.filter { !it.name.endsWith(".war") }
+
+                    war.project.configurations.runtime.each {
+                        if (it.name.endsWith(".war")) {
+                            def fileList = war.project.zipTree(it)
+                            if (project.convention.plugins.warOverlay.includeWarJars) {
+                                war.from fileList
+                            } else {
+                                war.from fileList.matching { exclude "**/*.jar" }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    }
+}
+
+/**
+ * Plugin convention to configure war overlay specific parameters
+ */
+class WarOverlayPluginConvention {
+    boolean includeWarJars = false
+
+    def warOverlay(Closure c) {
+        c.delegate = this
+        c()
+    }
+
+    def methodMissing(String name, args) {
+        this."${name}" = args[0]
+    }
+}

--- a/overlays/build.gradle
+++ b/overlays/build.gradle
@@ -1,30 +1,15 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath "org.scaldingspoon.gradle:gradle-waroverlay-plugin:${waroverlayPluginVersion}"
-    }
-}
+import scaldingspoon.gradle.WarOverlayPlugin
 
 subprojects {
+
     apply plugin: 'maven'
-    apply plugin: 'waroverlay'
+    apply plugin: WarOverlayPlugin
     apply plugin: org.apereo.portal.start.gradle.plugins.GradleTomcatDeployPlugin
 
     repositories {
         mavenLocal()
         mavenCentral()
         maven { url "https://jitpack.io" }
-    }
-
-    buildscript {
-        repositories {
-            jcenter()
-        }
-        dependencies {
-            classpath "org.scaldingspoon.gradle:gradle-waroverlay-plugin:${waroverlayPluginVersion}"
-        }
     }
 
     warOverlay {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [ ] tests are included
-   [ ] documentation is changed or added
-   [ ] [message properties][] have been updated with new phrases
-   [ ] view conforms with [WCAG 2.0 AA][]

##### Description of change
War Overlay Plugin is no longer available from JCenter, and it will not build from it's repo. 

Copying the plugin directly into this project.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
